### PR TITLE
feat: clilog-viewer プロジェクトをポートフォリオに追加 #30

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -127,6 +127,14 @@ export const projects: Project[] = [
         tags: ['.NET 8', 'C#', 'WPF'],
         githubUrl: 'https://github.com/suu3play/finder-scope',
     },
+    {
+        id: 7,
+        title: '📊 clilog-viewer',
+        description:
+            'AI CLIツールの会話ログをMarkdownファイルに変換し、高速チャットビューアーで表示するツール。SQLiteキャッシュによる50-150倍高速化、リアルタイムログ監視、Virtual Scrolling対応',
+        tags: ['Python', 'Flask', 'SQLite', 'JavaScript', 'HTML/CSS'],
+        githubUrl: 'https://github.com/suu3play/clilog-viewer',
+    },
 ];
 
 export const services: Service[] = [


### PR DESCRIPTION
## 概要
AI CLIツールの会話ログをMarkdownファイルに変換し、高速チャットビューアーで表示するPythonツール「clilog-viewer」をポートフォリオに追加

## 変更点
- **portfolio.ts**: projectsリストに新しいプロジェクト（id: 7）を追加
  - タイトル: 📊 clilog-viewer
  - 説明: AI CLIツールのログ変換と高速チャットビューアー機能
  - 技術タグ: Python, Flask, SQLite, JavaScript, HTML/CSS
  - GitHubリポジトリURL: https://github.com/suu3play/clilog-viewer
  - デモURL: 未設定（ローカルツールのため）

## テスト
- [x] TypeScript型チェック (tsc --noEmit)
- [x] ESLintによるコード品質チェック
- [x] ビルドテスト (npm run build)
- [x] 全てのコード品質チェック項目に合格
- [x] ブラウザでの表示確認（プロジェクトセクションに新規項目表示）

fixes #30