### PR TITLE
feat: Value-me 時給計算アプリをポートフォリオに追加 #31

### DIFF
--- a/src/data/portfolio.ts
+++ b/src/data/portfolio.ts
@@ -135,6 +135,14 @@ export const projects: Project[] = [
         tags: ['Python', 'Flask', 'SQLite', 'JavaScript', 'HTML/CSS'],
         githubUrl: 'https://github.com/suu3play/clilog-viewer',
     },
+    {
+        id: 8,
+        title: '💰 Value-me',
+        description:
+            '給与情報、労働時間、福利厚生などを総合的に考慮して正確な時給を算出するWebアプリケーション。月収・年収ベースでの計算、各種手当・ボーナス考慮、リアルタイム計算結果更新が特徴',
+        tags: ['React', 'TypeScript', 'Material-UI', 'Vite', 'Emotion'],
+        githubUrl: 'https://github.com/suu3play/value-me',
+    },
 ];
 
 export const services: Service[] = [


### PR DESCRIPTION
## 概要
給与情報、労働時間、福利厚生などを総合的に考慮して正確な時給を算出するWebアプリケーション「Value-me」をポートフォリオに追加

## 変更点
- **portfolio.ts**: projectsリストに新しいプロジェクト（id: 8）を追加
  - タイトル: 💰 Value-me
  - 説明: 時給計算機能とリアルタイム計算結果更新
  - 技術タグ: React, TypeScript, Material-UI, Vite, Emotion
  - GitHubリポジトリURL: https://github.com/suu3play/value-me
  - デモURL: 未設定（開発中のため）

## テスト
- [x] TypeScript型チェック (tsc --noEmit)
- [x] ESLintによるコード品質チェック
- [x] ビルドテスト (npm run build)
- [x] 全てのコード品質チェック項目に合格
- [x] モダンなフロントエンド技術スタックの検証
- [x] ブラウザでの表示確認（プロジェクトセクションに新規項目表示）

fixes #31