### PR TITLE
feat: モバイル表示の余白を調整 #50

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -9,7 +9,7 @@ const About: React.FC = () => {
 
     return (
         <section id="about" className="py-20">
-            <div className="max-w-4xl mx-auto px-5">
+            <div className="max-w-4xl mx-auto px-6">
                 <h2
                     className="text-center text-4xl font-bold mb-12 relative after:content-[''] after:absolute after:bottom-[-10px] after:left-1/2 after:-translate-x-1/2 after:w-12 after:h-1 after:bg-primary after:rounded-full after:block"
                     style={{ color: 'var(--color-text-primary)' }}

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -97,7 +97,7 @@ const Contact: React.FC = () => {
 
     return (
         <section id="contact" className="py-20">
-            <div className="max-w-6xl mx-auto px-5">
+            <div className="max-w-6xl mx-auto px-6">
                 <h2 className="text-center text-4xl font-bold mb-12 relative after:content-[''] after:absolute after:bottom-[-10px] after:left-1/2 after:-translate-x-1/2 after:w-12 after:h-1 after:bg-primary after:rounded-full after:block">
                     お問い合わせ
                 </h2>

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -34,7 +34,7 @@ const Hero: React.FC = () => {
                 backgroundImage: 'var(--color-bg-hero)',
             }}
         >
-            <div className="max-w-4xl mx-auto px-5 flex flex-col md:flex-row items-center gap-8">
+            <div className="max-w-4xl mx-auto px-6 flex flex-col md:flex-row items-center gap-8">
                 <div className="flex-1 max-w-2xl text-center md:text-left">
                     <h1 className="text-3xl md:text-5xl font-bold mb-4 animate-fade-in-up">
                         {displayText}

--- a/src/components/Projects.tsx
+++ b/src/components/Projects.tsx
@@ -5,7 +5,7 @@ import ProjectImage from './ProjectImage';
 const Projects: React.FC = () => {
     return (
         <section id="projects" className="py-20 ">
-            <div className="max-w-6xl mx-auto px-5">
+            <div className="max-w-6xl mx-auto px-6">
                 <h2 className="text-center text-4xl font-bold mb-12 relative after:content-[''] after:absolute after:bottom-[-10px] after:left-1/2 after:-translate-x-1/2 after:w-12 after:h-1 after:bg-primary after:rounded-full after:block">
                     プロジェクト
                 </h2>

--- a/src/components/Services.tsx
+++ b/src/components/Services.tsx
@@ -4,7 +4,7 @@ import { services } from '../data/portfolio';
 const Services: React.FC = () => {
     return (
         <section id="services" className="py-20">
-            <div className="max-w-6xl mx-auto px-5">
+            <div className="max-w-6xl mx-auto px-6">
                 <h2 className="text-center text-4xl font-bold mb-12 relative after:content-[''] after:absolute after:bottom-[-10px] after:left-1/2 after:-translate-x-1/2 after:w-12 after:h-1 after:bg-primary after:rounded-full after:block">
                     担当範囲
                 </h2>

--- a/src/components/Skills.tsx
+++ b/src/components/Skills.tsx
@@ -4,7 +4,7 @@ import { skillCategories } from '../data/portfolio';
 const Skills: React.FC = () => {
     return (
         <section id="skills" className="py-20">
-            <div className="max-w-6xl mx-auto px-5">
+            <div className="max-w-6xl mx-auto px-6">
                 <h2 className="text-center text-4xl font-bold mb-12 relative after:content-[''] after:absolute after:bottom-[-10px] after:left-1/2 after:-translate-x-1/2 after:w-12 after:h-1 after:bg-primary after:rounded-full after:block">
                     スキル
                 </h2>


### PR DESCRIPTION
## 概要
Issue #50 対応: スマートフォンでの表示時の余白を適切に調整し、モバイルユーザーの読みやすさを向上させました。

## 変更点

### UI改善
- 全セクションの左右余白を `px-5` (20px) から `px-6` (24px) に変更
- 変更対象コンポーネント:
  - Hero
  - About
  - Skills
  - Services
  - Projects
  - Contact

### 技術的詳細
- Tailwind CSS のクラス変更のみ
- レスポンシブ動作に影響なし
- 既存機能への影響なし

## テスト
- [x] TypeScript型チェック合格
- [x] ESLint チェック合格
- [x] ビルド成功
- [x] モバイル表示確認 (375px幅)
- [x] タブレット表示確認 (768px幅)
- [x] コード品質チェック合格 (logs/code_check_202510012104.md)

fixes #50